### PR TITLE
amending description in deployment.yaml file

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       s3_bucket:
-        description: 'mvws9-chloe20230321174433047800000003'  #name of S3 bucket created through IaC
+        description: 'The S3 bucket name'
         required: true
         type: string
 jobs:


### PR DESCRIPTION
Have amended the script for the workflow_dispatch trigger - the code requests that the S3 bucket name is entered as an input value. Previously a specific S3 bucket name was entered under description, have changed this to a description of the parameter instead, per GitHub documentation:

inputs.<input_id>.description
Required A string description of the input parameter.